### PR TITLE
Feature/default shell

### DIFF
--- a/wifi-password
+++ b/wifi-password
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version="0.0.2"
+version="0.0.3"
 
 # Shows the usage
 function usage() {

--- a/wifi-password
+++ b/wifi-password
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 version="0.0.2"
 


### PR DESCRIPTION
Since Debian links /bin/sh to dash but still comes with bash installed by default, changing the shebang will work seamlessly.
Closes #3 